### PR TITLE
Fix for URLs with GET parameters, like `http://example.com?page=2`

### DIFF
--- a/RTLabelProject/Classes/RTLabel.m
+++ b/RTLabelProject/Classes/RTLabel.m
@@ -888,9 +888,9 @@
 			for (int i=1; i<[textComponents count]; i++)
 			{
 				NSArray *pair = [[textComponents objectAtIndex:i] componentsSeparatedByString:@"="];
-				if ([pair count]==2)
+				if ([pair count]>=2)
 				{
-					[attributes setObject:[pair objectAtIndex:1] forKey:[pair objectAtIndex:0]];
+					[attributes setObject:[[pair subarrayWithRange:NSMakeRange(1, [pair count] - 1)] componentsJoinedByString:@"="] forKey:[pair objectAtIndex:0]];
 				}
 			}
 			//NSLog(@"%@", attributes);


### PR DESCRIPTION
URLs with GET parameters, like `http://example.com?page=2` wouldn't be parsed right, because the attributes are split on the `=` equal sign, resulting in an attempted nil-insertion on an NSMutableDictionary. By setting the required pair count to equal or greater than 2 and joining the remaining subarray with `=`, we get the full URL again.
