### PR TITLE
Fix invalid context errors

### DIFF
--- a/RTLabelProject/Classes/RTLabel.m
+++ b/RTLabelProject/Classes/RTLabel.m
@@ -212,11 +212,14 @@
 	
     if (!self._plainText) return;
 	
-    // Drawing code.
-	CGContextRef context = UIGraphicsGetCurrentContext();
-	CGContextSetTextMatrix(context, CGAffineTransformIdentity);
-	CGAffineTransform flipVertical = CGAffineTransformMake(1,0,0,-1,0,self.frame.size.height);
-	CGContextConcatCTM(context, flipVertical);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (context != NULL)
+    {
+        // Drawing code.
+        CGContextSetTextMatrix(context, CGAffineTransformIdentity);
+        CGAffineTransform flipVertical = CGAffineTransformMake(1,0,0,-1,0,self.frame.size.height);
+        CGContextConcatCTM(context, flipVertical);
+    }
 	
 	// Initialize an attributed string.
 	CFStringRef string = (CFStringRef)self._plainText;


### PR DESCRIPTION
By putting the context-sensitive code (flipping the context transform) in a conditional checking for the existence of `context`, we can suppress a lot of runtime errors, like `CGContextSetTextMatrix: invalid context`. Calculating the height is not affected, eventhough there is no context to flip.
