### PR TITLE
on iOS4.3,optimumSize is smaller to draw unicode character

### DIFF
--- a/RTLabelProject/Classes/RTLabel.m
+++ b/RTLabelProject/Classes/RTLabel.m
@@ -329,7 +329,9 @@
 	
 	CFRange range;
 	CGSize constraint = CGSizeMake(self.frame.size.width, CGFLOAT_MAX);
-	self.optimumSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, [self.plainText length]), nil, constraint, &range);
+	//self.optimumSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, [self.plainText length]), nil, constraint, &range);
+    CGSize optimumSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, [self.plainText length]), nil, constraint, &range);
+    self.optimumSize = CGSizeMake(ceilf(optimumSize.width), ceilf(optimumSize.height));
 	
 	
 	if (self.currentSelectedButtonComponentIndex==-1)


### PR DESCRIPTION
Hi，
I want to use RTLabel to display chinese character. but on iOS4.3 device, it's doesn't work. I find out the optimumSize maybe smaller in this case. so I add “ceilf()” function with the size. it's OK now.
