### PR TITLE
Crash when there is space near an '=' char.

### DIFF
--- a/RTLabelProject/Classes/DemoTableViewController.m
+++ b/RTLabelProject/Classes/DemoTableViewController.m
@@ -69,7 +69,7 @@
 		[self.dataArray addObject:row2];
 		
 		NSMutableDictionary *row3 = [NSMutableDictionary dictionary];
-		[row3 setObject:@"clickable link - <a href='http://store.apple.com'>link to apple store</a> <a href='http://www.google.com'>link to google</a> <a href='http://www.yahoo.com'>link to yahoo</a> <a href='https://github.com/honcheng/RTLabel'>link to RTLabel in GitHub</a> <a href='http://www.wiki.com'>link to wiki.com website</a>" forKey:@"text"];
+		[row3 setObject:@"clickable link - <a target = _blank href = 'http://store.apple.com'>link to apple store</a> <a href='http://www.google.com'>link to google</a> <a href='http://www.yahoo.com'>link to yahoo</a> <a href='https://github.com/honcheng/RTLabel'>link to RTLabel in GitHub</a> <a href='http://www.wiki.com'>link to wiki.com website</a>" forKey:@"text"];
 		[self.dataArray addObject:row3];
         
         NSMutableDictionary *row4 = [NSMutableDictionary dictionary];

--- a/RTLabelProject/Classes/RTLabel.m
+++ b/RTLabelProject/Classes/RTLabel.m
@@ -857,6 +857,23 @@
 	return [components copy];
 }
 
++ (NSString *) fixSpacesNearEquals:(NSString *)text
+{
+    NSArray *textComponents = [text componentsSeparatedByString:@"="];
+    NSMutableArray * ret;
+    NSEnumerator * en;
+    NSString *str;
+    
+    en = [textComponents objectEnumerator];
+    ret = [[NSMutableArray alloc] initWithCapacity:[textComponents count]];
+    
+    while (str = [en nextObject]) {
+        [ret addObject:[str stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+    }
+    
+    return [ret componentsJoinedByString:@"="];
+}
+
 + (RTLabelExtractedComponent*)extractTextStyleFromText:(NSString*)data paragraphReplacement:(NSString*)paragraphReplacement
 {
 	NSScanner *scanner = nil; 
@@ -910,7 +927,8 @@
 		else
 		{
 			// start of tag
-			NSArray *textComponents = [[text substringFromIndex:1] componentsSeparatedByString:@" "];
+            NSString * fixedText = [self fixSpacesNearEquals:[text substringFromIndex:1]];
+			NSArray *textComponents = [fixedText componentsSeparatedByString:@" "];
 			tag = [textComponents objectAtIndex:0];
 			//NSLog(@"start of tag: %@", tag);
 			NSMutableDictionary *attributes = [NSMutableDictionary dictionary];


### PR DESCRIPTION
When link have a space near '=' char there was application crash. For example &lt;a href = 'http://apple.com' &gt;apple&lt;/a&gt; or &lt;a href='http://apple.com' target = _blank &lt;/a&gt;

This merge req. is fixing it.
