### PR TITLE
Fix warning and support iOS 6

### DIFF
--- a/RTLabelProject/Classes/DemoTableViewController.m
+++ b/RTLabelProject/Classes/DemoTableViewController.m
@@ -39,6 +39,12 @@
 #import "DemoTableViewCell.h"
 #import "RTLabel.h"
 
+#if (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0)
+#define TextAlignmentCenter NSTextAlignmentCenter
+#else
+#define TextAlignmentCenter UITextAlignmentCenter
+#endif
+
 @implementation DemoTableViewController
 
 #pragma mark -
@@ -57,7 +63,7 @@
 		[titleLabel setFont:[UIFont fontWithName:@"HelveticaNeue-CondensedBold" size:20]];
 		[titleLabel setText:@"RTLabel"];
 		[self.navigationItem setTitleView:titleLabel];
-		[titleLabel setTextAlignment:UITextAlignmentCenter];
+		[titleLabel setTextAlignment:TextAlignmentCenter];
 		
 		_dataArray = [NSMutableArray array];
 		NSMutableDictionary *row1 = [NSMutableDictionary dictionary];

--- a/RTLabelProject/Classes/RTLabel.h
+++ b/RTLabelProject/Classes/RTLabel.h
@@ -63,7 +63,7 @@ typedef enum
 @property (nonatomic, assign) int componentIndex;
 @property (nonatomic, copy) NSString *text;
 @property (nonatomic, copy) NSString *tagLabel;
-@property (nonatomic) NSMutableDictionary *attributes;
+@property (nonatomic, strong) NSMutableDictionary *attributes;
 @property (nonatomic, assign) int position;
 
 - (id)initWithString:(NSString*)aText tag:(NSString*)aTagLabel attributes:(NSMutableDictionary*)theAttributes;


### PR DESCRIPTION
1. Add macro for support iOS 6.
2. Fix about warning. Default property attribute ‘assign’ not appropriate for non-GC object.
