### PR TITLE
Added method to determine bounding rect of links

### DIFF
--- a/RTLabelProject/Classes/RTLabel.h
+++ b/RTLabelProject/Classes/RTLabel.h
@@ -95,12 +95,16 @@ typedef enum
 @property (nonatomic, assign) int currentSelectedButtonComponentIndex;
 @property (nonatomic, assign) CFRange visibleRange;
 @property (nonatomic, assign) BOOL highlighted;
+@property (nonatomic, readonly) NSMutableDictionary *anchorsBoundingRects;
 
 // set text
 - (void)setText:(NSString*)text;
 + (RTLabelExtractedComponent*)extractTextStyleFromText:(NSString*)data paragraphReplacement:(NSString*)paragraphReplacement;
 // get the visible text
 - (NSString*)visibleText;
+
+// get the bounding rect of the anchor referenced by its 'id' attribute (<a href='' id=''>...</a>), relatively to the view
+- (CGRect) boundingRectForAnchorWithIdentifier: (NSString *) identifier;
 
 // alternative
 // from susieyy http://github.com/susieyy

--- a/RTLabelProject/Classes/RTLabel.m
+++ b/RTLabelProject/Classes/RTLabel.m
@@ -176,6 +176,12 @@
 	[self setNeedsDisplay];
 }
 
+- (CGRect) boundingRectForAnchorWithIdentifier:(NSString *)identifier
+{
+	NSValue *value = [_anchorsBoundingRects objectForKey:identifier];
+	return value? value.CGRectValue : CGRectZero;
+}
+
 - (void)drawRect:(CGRect)rect 
 {
 	[self render];
@@ -280,6 +286,12 @@
 			value = [value stringByReplacingOccurrencesOfString:@"'" withString:@""];
 			[component.attributes setObject:value forKey:@"href"];
 			
+			value = [component.attributes objectForKey:@"id"];
+			if (value) {
+				value = [value stringByReplacingOccurrencesOfString:@"'" withString:@""];
+				[component.attributes setObject:value forKey:@"id"];
+			}
+			
 			[links addObject:component];
 		}
 		else if ([component.tagLabel caseInsensitiveCompare:@"u"] == NSOrderedSame || [component.tagLabel caseInsensitiveCompare:@"uu"] == NSOrderedSame)
@@ -335,7 +347,8 @@
 	if (self.currentSelectedButtonComponentIndex==-1)
 	{
 		// only check for linkable items the first time, not when it's being redrawn on button pressed
-		
+		_anchorsBoundingRects = @{}.mutableCopy;
+
 		for (RTLabelComponent *linkableComponents in links)
 		{
 			float height = 0.0;
@@ -360,8 +373,12 @@
 					
 					CGFloat button_width = primaryOffset2 - primaryOffset;
 					
-					RTLabelButton *button = [[RTLabelButton alloc] initWithFrame:CGRectMake(primaryOffset+origin.x, height, button_width, ascent+descent)];
+					CGRect buttonFrame = CGRectMake(primaryOffset+origin.x, height, button_width, ascent+descent);
+					RTLabelButton *button = [[RTLabelButton alloc] initWithFrame:buttonFrame];
 					
+					if ([linkableComponents.attributes objectForKey:@"id"])
+						_anchorsBoundingRects[[linkableComponents.attributes objectForKey:@"id"]] = [NSValue valueWithCGRect:buttonFrame];
+
 					[button setBackgroundColor:[UIColor colorWithWhite:0 alpha:0]];
 					[button setComponentIndex:linkableComponents.componentIndex];
 					


### PR DESCRIPTION
Added
- (CGRect) boundingRectForAnchorWithIdentifier: (NSString *) identifier;
  which returns the bounding rect of the anchor with the 'id' set to
  identifier.
