### PR TITLE
fix the bug :

### DIFF
--- a/RTLabelProject/Classes/RTLabel.m
+++ b/RTLabelProject/Classes/RTLabel.m
@@ -873,7 +873,7 @@
 		[scanner scanUpToString:@">" intoString:&text];
 		
 		NSString *delimiter = [NSString stringWithFormat:@"%@>", text];
-		int position = [data rangeOfString:delimiter].location;
+		long position = [data rangeOfString:delimiter].location;
 		if (position!=NSNotFound)
 		{
 			if ([delimiter rangeOfString:@"<p"].location==0)


### PR DESCRIPTION
when the data is too long it will throw exception : out of bounds; string length 60. This will become an exception for apps linked after 10.10 and iOS 8. Warning shown once per app execution.



just little change！！！